### PR TITLE
feat(elsafile): env manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ Thumbs.db
 /docs/
 /my-project/
 /elsa/
+/myapp/
 elsa-*
 coverage.out
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Features
 - 
 
-## [1.0.4] - 2025-09-22
+## [1.0.5] - 2026-05-23
 
-### Features
-- **Updated BuiltinCommands List**: Added missing commands to the static fallback list for better compatibility
-  - Added `generate`, `gen`, `new`, and `make` commands to the BuiltinCommands constant
-  - Ensures proper conflict detection even when dynamic detection is not available
-  - Update template initial Elsafile
+- **Elsa Env Manager** — local environment variable manager with embedded web UI
+  - `elsa env serve` — start localhost web server (default `127.0.0.1:1999`)
+  - `elsa env reset` — delete local database with 8-character random confirmation code
+  - **Environments** — custom groups (local, staging, production, etc.) with sort order
+  - **Variables** — comparison table across environments, per-row edit, search, pagination (10/25/50/100)
+  - **Templates** — Go `text/template` export (`.env` or custom filename, copy/download)
+  - Environment column picker (dropdown, max 5 columns at a time)
+  - Auto-open system browser when `serve` starts (`--no-browser` to disable)
+  - SQLite storage at user config dir: `elsa/elsaenvmanager.db` (local only, not published)
+  - REST API for environments, variables, and templates
+  - `ENV_GUIDELINE.md` — complete feature documentation

--- a/ENV_GUIDELINE.md
+++ b/ENV_GUIDELINE.md
@@ -1,0 +1,348 @@
+# Elsa Env Manager - Complete Guide
+
+**Elsa Env Manager** is a local environment variable manager with a built-in web UI. Manage environment groups (local, staging, production), compare values side-by-side, define export templates with Go `text/template` syntax, and generate `.env` files — all stored privately on your machine.
+
+> 🔒 **Privacy**: All data is stored in a local SQLite database under your user config directory. The web server binds to `127.0.0.1` by default and is not published or synced anywhere.
+
+## 🎯 Overview
+
+Elsa Env Manager helps you:
+
+- **Organize environments** as custom groups (local, staging, production, etc.)
+- **Manage variables** with a comparison table across up to 5 environments at once
+- **Export templates** using Go template syntax (`{{.DB_HOST}}`)
+- **Generate files** as `.env` or custom filenames, or copy output to clipboard
+
+The UI is embedded in the Elsa binary (`go:embed`) — a single executable, no separate frontend build step.
+
+## 🏗️ Architecture
+
+```
+elsa env serve
+      ↓
+┌─────────────────────────────────────┐
+│  HTTP Server (localhost)            │
+│  ├── Embedded Web UI (dark mode)    │
+│  └── REST API (/api/...)            │
+└─────────────────────────────────────┘
+      ↓
+┌─────────────────────────────────────┐
+│  SQLite (user config directory)     │
+│  ├── environments                   │
+│  ├── variables + values             │
+│  └── templates                      │
+└─────────────────────────────────────┘
+```
+
+| Component | Path |
+|-----------|------|
+| CLI command | `cmd/env/` |
+| Business logic | `internal/envmanager/` |
+| Web UI | `internal/envmanager/web/` |
+
+## 🚀 Quick Start
+
+### 1. Start the web UI
+
+```bash
+elsa env serve
+```
+
+The server starts at **http://127.0.0.1:1999** (default) and opens your system browser automatically.
+
+### 2. Create environment groups
+
+Open the **Environments** page and add groups such as:
+
+- `local`
+- `staging`
+- `production`
+
+Names must be unique. Sort order controls display order in lists.
+
+### 3. Add variables
+
+Open the **Variables** page:
+
+1. Select up to **5 environment columns** from the **Columns** dropdown
+2. Edit values per row in the comparison table
+3. Add new keys in the footer row
+4. Use **Search** to filter by key name (sorted A–Z)
+
+Changes save automatically when you leave a cell (blur) or press Enter.
+
+### 4. Create export templates
+
+Open the **Templates** page:
+
+1. Click **+ New template**
+2. Set a unique name and template body
+3. Use Go template syntax referencing your variable keys
+
+Example template body:
+
+```dotenv
+DB_HOST={{.DB_HOST}}
+DB_USER={{.DB_USER}}
+DB_PASS={{.DB_PASS}}
+DB_PORT={{.DB_PORT}}
+```
+
+### 5. Export
+
+- **Per environment**: **Export .env** on the Environments page
+- **From template**: **Export** on a template → choose environment → **Generate** → **Copy** or **Download**
+
+## 📋 Features by Page
+
+### Environments
+
+| Feature | Description |
+|---------|-------------|
+| Create group | Custom name + sort order |
+| Edit / Delete | Update name or remove group (values for that env are deleted) |
+| Export .env | Generate dotenv file for one environment |
+
+**Validation**
+
+- Name is required
+- Name must be unique (database constraint)
+
+### Variables
+
+| Feature | Description |
+|---------|-------------|
+| Comparison table | Keys in the left column; environment values in columns |
+| Column picker | Dropdown, max **5** environments at a time |
+| Search | Filter by key name |
+| Pagination | 10 / 25 / 50 / 100 rows per page |
+| Inline add | New key row in table footer |
+| Per-row save | Auto-save on blur or Enter |
+
+**Validation**
+
+- Key is required and must be unique
+- At least one environment column must be selected
+
+### Templates
+
+| Feature | Description |
+|---------|-------------|
+| Create / Edit / Delete | Manage named templates |
+| Go templates | Use `{{.VARIABLE_KEY}}` — keys match variable names |
+| Export | Render template for a chosen environment |
+| Preview | Generate, copy, or download output |
+
+**Validation**
+
+- Name is required and unique (case-insensitive)
+- Body is required
+
+**Special keys**: If a variable key contains characters invalid for Go template field access (e.g. `MY-KEY`), use:
+
+```gotemplate
+{{index . "MY-KEY"}}
+```
+
+## 📟 Commands Reference
+
+### `elsa env`
+
+Parent command for environment management.
+
+```bash
+elsa env --help
+```
+
+### `elsa env reset`
+
+Permanently delete the local env manager database. Requires typing a random **8-character** confirmation code (letters `a-z` / `A-Z` and digits `0-9` only — case-sensitive, no spaces or symbols).
+
+```bash
+elsa env reset
+elsa env reset --db "C:\path\to\custom.db"
+```
+
+Example session:
+
+```
+⚠️  WARNING: This will permanently delete ALL env manager data.
+Database: C:\Users\you\AppData\Roaming\elsa\elsaenvmanager.db
+Type this exact code to confirm (8 letters/digits, case-sensitive):
+aB3xK9mZ
+> aB3xK9mZ
+✅ Database deleted: ...
+```
+
+| Flag | Description |
+|------|-------------|
+| `--db` | Custom SQLite path (same as `serve`) |
+
+> Stop `elsa env serve` first if the database file is locked.
+
+### `elsa env serve`
+
+Start the local web server and UI.
+
+```bash
+elsa env serve
+elsa env serve --port 8080
+elsa env serve --host 127.0.0.1 --port 3000
+elsa env serve --db "C:\path\to\custom.db"
+elsa env serve --no-browser
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--host` | `127.0.0.1` | Host to bind. Use `127.0.0.1` to keep traffic local |
+| `--port` | `1999` | HTTP port |
+| `--db` | *(auto)* | Custom SQLite database path |
+| `--no-browser` | `false` | Do not open the system browser on start |
+
+### Elsafile integration
+
+Add to your project `Elsafile`:
+
+```bash
+# Start env manager UI
+env:
+	elsa env serve
+
+# Custom port, no browser (e.g. CI / remote dev)
+env/headless:
+	elsa env serve --port 9473 --no-browser
+```
+
+Run with:
+
+```bash
+elsa run env
+elsa run env/headless
+```
+
+## 💾 Data Storage
+
+### Default database location
+
+| OS | Path |
+|----|------|
+| Windows | `%APPDATA%\elsa\elsaenvmanager.db` |
+| macOS | `~/Library/Application Support/elsa/elsaenvmanager.db` |
+| Linux | `~/.config/elsa/elsaenvmanager.db` |
+
+The config directory is created with restricted permissions (`0700`).
+
+### Custom database
+
+```bash
+elsa env serve --db "./my-env.db"
+```
+
+Use a custom path when you want project-specific or portable storage.
+
+### What is stored
+
+| Table | Content |
+|-------|---------|
+| `environments` | Group names (local, staging, …) |
+| `variables` | Env keys (`DB_HOST`, …) |
+| `values` | Per-environment values |
+| `templates` | Export template name + body |
+
+**Not stored**: Generated `.env` files (export is on-demand only).
+
+## 🔒 Security Best Practices
+
+1. **Keep default host** `127.0.0.1` — avoids exposing the UI on your network
+2. **Do not commit** database files or exported `.env` files to git
+3. **Use `--no-browser`** on shared/headless machines if needed
+4. **Backup** the SQLite file before major changes: copy `elsaenvmanager.db`
+
+> ⚠️ Binding to `0.0.0.0` makes the UI reachable from other machines on your network. Only do this on trusted networks.
+
+## 🌐 REST API
+
+The web UI uses a JSON API (for reference or automation):
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/api/environments` | List environments |
+| `POST` | `/api/environments` | Create environment |
+| `PUT` | `/api/environments/{id}` | Update environment |
+| `DELETE` | `/api/environments/{id}` | Delete environment |
+| `POST` | `/api/environments/{id}/export` | Export dotenv for one env |
+| `GET` | `/api/variables` | List variables with values |
+| `POST` | `/api/variables` | Create variable |
+| `PUT` | `/api/variables/{id}` | Update variable |
+| `DELETE` | `/api/variables/{id}` | Delete variable |
+| `GET` | `/api/templates` | List templates |
+| `POST` | `/api/templates` | Create template |
+| `PUT` | `/api/templates/{id}` | Update template |
+| `DELETE` | `/api/templates/{id}` | Delete template |
+| `POST` | `/api/templates/{id}/render` | Render template for an environment |
+
+## 🛠️ Troubleshooting
+
+### Browser does not open
+
+```bash
+elsa env serve --no-browser
+# Open manually: http://127.0.0.1:1999
+```
+
+### Port already in use
+
+```bash
+elsa env serve --port 2026
+```
+
+### "template name already exists"
+
+Template names are unique (case-insensitive). Choose a different name or edit the existing template.
+
+### "Maximum 5 environment columns"
+
+The comparison table supports at most 5 environment columns. Uncheck one environment before selecting another.
+
+### Database locked (SQLite) / "being used by another process"
+
+This is **normal on Windows** when the database file is still open — not a bug on your PC.
+
+**Common cause:** `elsa env serve` is still running in another terminal.
+
+**Fix:**
+1. Find the terminal where `elsa env serve` is running
+2. Press **Ctrl+C** to stop it
+3. Run `elsa env reset` again
+
+Also close DB browser tools (SQLite viewers) if they have `elsaenvmanager.db` open.
+
+### Reset confirmation failed
+
+The code is **case-sensitive** and must match exactly (8 characters). Run `elsa env reset` again to get a new code.
+
+### Template renders empty values
+
+Ensure:
+
+1. The variable key exists (e.g. `DB_HOST`)
+2. A value is set for the selected environment
+3. Template syntax matches the key: `{{.DB_HOST}}`
+
+## 💡 Best Practices
+
+1. **Naming**: Use `SCREAMING_SNAKE_CASE` for keys (`DB_HOST`, `API_KEY`)
+2. **Environments**: Mirror your deploy targets (`local`, `staging`, `production`)
+3. **Templates**: One template per output format (`.env`, `config.yaml`, Docker env file)
+4. **Compare**: Select staging + production columns to spot differences quickly
+5. **Export**: Use templates for non-dotenv formats; use **Export .env** for standard dotenv
+
+## 🔗 Related Documentation
+
+- [Elsa README](README.md) — Main project overview
+- [Elsa Init & Run Guide](INIT_RUN_GUIDELINE.md) — Elsafile custom commands
+- [Migration Guide](MIGRATION_GUIDELINE.md) — Database migrations (separate from env manager DB)
+
+---
+
+**Elsa Env Manager** — Keep secrets local, compare environments easily, export with confidence. 🔐

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Version](https://img.shields.io/badge/Version-1.0.0-green.svg)](https://github.com/risoftinc/elsa)
 [![License](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-**Elsa** is a powerful developer productivity toolkit for Go that provides database migration management, file watching, custom command definitions, code generation, and project automation capabilities.
+**Elsa** is a powerful developer productivity toolkit for Go that provides database migration management, local environment variable management, file watching, custom command definitions, code generation, and project automation capabilities.
 
 ```
       ___           ___       ___           ___     
@@ -48,6 +48,13 @@
 - **Cross-Platform Cache**: Platform-specific cache locations (Windows/macOS/Linux)
 - **Git-Based Caching**: Cache paths follow git URL structure for better organization
 - **Module Management**: Automatic go.mod module name creation
+
+### 🔐 Env Manager (Local)
+- **Web UI**: Embedded in a single binary
+- **Environment Groups**: Custom groups (local, staging, production)
+- **Variable Comparison**: Side-by-side table across up to 5 environments
+- **Go Templates**: Export with `{{.KEY}}` syntax — copy or download `.env` files
+- **Private Storage**: SQLite in user config dir; localhost-only by default
 
 ### 🏗️ Make System
 - **Dynamic Template Types**: Generate files from configurable templates
@@ -143,7 +150,18 @@ elsa make repository health/health_repository
 elsa make list
 ```
 
-### 5. Custom Commands
+### 5. Env Manager
+```bash
+# Start local env manager (opens browser automatically)
+elsa env serve
+
+# Custom port, skip browser open
+elsa env serve --port 8080 --no-browser
+```
+
+See [Env Manager Guide](ENV_GUIDELINE.md) for environments, variables, templates, and export.
+
+### 6. Custom Commands
 ```bash
 # List available commands from Elsafile
 elsa list
@@ -243,6 +261,16 @@ Run: `elsa generate` to create `elsa_gen.go` with automatic dependency injection
 | `--output, -o` | Output directory (default: current) |
 | `--force, -f` | Overwrite existing directory |
 | `--refresh` | Force refresh template cache |
+
+### Env Manager Commands
+| Command | Description |
+|---------|-------------|
+| `elsa env serve` | Start local env manager web UI |
+| `elsa env reset` | Delete local database (requires 8-char confirmation code) |
+| `--host` | Host to bind (default: `127.0.0.1`) |
+| `--port` | HTTP port (default: `1999`) |
+| `--db` | Custom SQLite database path |
+| `--no-browser` | Do not open browser on start |
 
 ### Make Commands
 | Command | Description |
@@ -454,12 +482,17 @@ go build -o elsa ./cmd/elsa
   - Dependency definition
   - Advanced examples
   - Troubleshooting and best practices
+- **[Env Manager Guide](ENV_GUIDELINE.md)** - Local environment variable manager
+  - Environment groups, variables, and templates
+  - Comparison table, export, and Go template syntax
+  - Security, data storage, and REST API reference
 
 ### Command Reference
 - `elsa --help` - General help
 - `elsa make --help` - Make system help
 - `elsa migration --help` - Migration commands
 - `elsa watch --help` - File watching options
+- `elsa env --help` - Env manager commands
 
 ## 📄 License
 

--- a/cmd/elsa/main.go
+++ b/cmd/elsa/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	version = "1.0.4"
+	version = "1.0.5"
 )
 
 func main() {

--- a/cmd/env/env.go
+++ b/cmd/env/env.go
@@ -1,0 +1,18 @@
+package env
+
+import (
+	"github.com/spf13/cobra"
+	"go.risoftinc.com/elsa/constants"
+)
+
+// EnvCmd is the parent command for environment management
+var EnvCmd = &cobra.Command{
+	Use:   constants.EnvCommandUsage,
+	Short: constants.EnvCommandShort,
+	Long:  constants.EnvCommandLong,
+}
+
+func init() {
+	EnvCmd.AddCommand(ServeCmd)
+	EnvCmd.AddCommand(ResetCmd)
+}

--- a/cmd/env/reset.go
+++ b/cmd/env/reset.go
@@ -1,0 +1,75 @@
+package env
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"go.risoftinc.com/elsa/constants"
+	"go.risoftinc.com/elsa/internal/envmanager"
+)
+
+const confirmCodeLength = 8
+
+var resetDB string
+
+var ResetCmd = &cobra.Command{
+	Use:   constants.EnvResetUsage,
+	Short: constants.EnvResetShort,
+	Long:  constants.EnvResetLong,
+	RunE:  runReset,
+}
+
+func init() {
+	ResetCmd.Flags().StringVar(&resetDB, constants.EnvFlagDB, "", constants.EnvFlagDBUsage)
+}
+
+func runReset(cmd *cobra.Command, args []string) error {
+	dbPath := resetDB
+	if dbPath == "" {
+		var err error
+		dbPath, err = envmanager.DefaultDBPath()
+		if err != nil {
+			return err
+		}
+	}
+
+	code, err := envmanager.GenerateConfirmCode(confirmCodeLength)
+	if err != nil {
+		return fmt.Errorf("generate confirmation code: %w", err)
+	}
+
+	if err := envmanager.CheckDatabaseNotInUse(dbPath); err != nil {
+		if errors.Is(err, envmanager.ErrDatabaseInUse) {
+			fmt.Println(constants.MsgEnvResetInUseHint)
+		}
+		return err
+	}
+
+	fmt.Println(constants.MsgEnvResetWarning)
+	fmt.Printf(constants.MsgEnvResetDatabase+"\n", dbPath)
+	fmt.Printf(constants.MsgEnvResetTypeCode+"\n", code)
+	fmt.Print(constants.MsgEnvResetPrompt)
+
+	reader := bufio.NewReader(os.Stdin)
+	input, err := reader.ReadString('\n')
+	if err != nil {
+		return fmt.Errorf("read confirmation: %w", err)
+	}
+	input = strings.TrimSpace(input)
+
+	if input != code {
+		fmt.Println(constants.MsgEnvResetAborted)
+		return fmt.Errorf(constants.ErrEnvResetMismatch)
+	}
+
+	if err := envmanager.DeleteDatabase(dbPath); err != nil {
+		return err
+	}
+
+	fmt.Printf(constants.MsgEnvResetSuccess+"\n", dbPath)
+	return nil
+}

--- a/cmd/env/serve.go
+++ b/cmd/env/serve.go
@@ -1,0 +1,109 @@
+package env
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+	"go.risoftinc.com/elsa/constants"
+	"go.risoftinc.com/elsa/internal/envmanager"
+)
+
+var (
+	serveHost     string
+	servePort     string
+	serveDB       string
+	serveNoBrowser bool
+)
+
+var ServeCmd = &cobra.Command{
+	Use:   constants.EnvServeUsage,
+	Short: constants.EnvServeShort,
+	Long:  constants.EnvServeLong,
+	RunE:  runServe,
+}
+
+func init() {
+	ServeCmd.Flags().StringVar(&serveHost, constants.EnvFlagHost, constants.DefaultEnvHost, constants.EnvFlagHostUsage)
+	ServeCmd.Flags().StringVar(&servePort, constants.EnvFlagPort, constants.DefaultEnvPort, constants.EnvFlagPortUsage)
+	ServeCmd.Flags().StringVar(&serveDB, constants.EnvFlagDB, "", constants.EnvFlagDBUsage)
+	ServeCmd.Flags().BoolVar(&serveNoBrowser, constants.EnvFlagNoBrowser, false, constants.EnvFlagNoBrowserUsage)
+}
+
+func runServe(cmd *cobra.Command, args []string) error {
+	dbPath := serveDB
+	if dbPath == "" {
+		var err error
+		dbPath, err = envmanager.DefaultDBPath()
+		if err != nil {
+			return err
+		}
+	}
+
+	db, err := envmanager.OpenDB(dbPath)
+	if err != nil {
+		return err
+	}
+
+	store := envmanager.NewStore(db)
+	server, err := envmanager.NewServer(store)
+	if err != nil {
+		return err
+	}
+
+	addr := net.JoinHostPort(serveHost, servePort)
+	browserURL := envmanager.BrowserURL(serveHost, servePort)
+	httpServer := &http.Server{
+		Addr:              addr,
+		Handler:           server.Handler(),
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	fmt.Printf(constants.MsgEnvDatabase+"\n", dbPath)
+	fmt.Printf(constants.MsgEnvStarting+"\n", browserURL)
+	fmt.Println(constants.MsgEnvPressCtrlC)
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = httpServer.Shutdown(shutdownCtx)
+	}()
+
+	errCh := make(chan error, 1)
+	go func() {
+		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			errCh <- err
+		}
+		close(errCh)
+	}()
+
+	if !serveNoBrowser {
+		go func() {
+			if err := envmanager.OpenBrowserWhenReady(browserURL); err != nil {
+				fmt.Fprintf(os.Stderr, "Could not open browser: %v\n", err)
+				fmt.Fprintf(os.Stderr, "Open manually: %s\n", browserURL)
+			}
+		}()
+	}
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			log.Fatal(err)
+		}
+	case <-ctx.Done():
+	}
+
+	return nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"runtime"
 
 	"github.com/spf13/cobra"
+	envcmd "go.risoftinc.com/elsa/cmd/env"
 	"go.risoftinc.com/elsa/cmd/elsafile"
 	"go.risoftinc.com/elsa/cmd/generate"
 	"go.risoftinc.com/elsa/cmd/make"
@@ -58,6 +59,9 @@ func init() {
 
 	// Add make command
 	rootCmd.AddCommand(make.MakeCmd)
+
+	// Add env manager command
+	rootCmd.AddCommand(envcmd.EnvCmd)
 }
 
 // SetVersionInfo sets the version information for the application

--- a/constants/env.go
+++ b/constants/env.go
@@ -1,0 +1,51 @@
+package constants
+
+// Env manager command constants
+const (
+	EnvCommandUsage = "env"
+	EnvCommandShort = "Manage local environment variables"
+	EnvCommandLong  = `Local environment manager with a web UI.
+
+Stores all data in a private SQLite database on your machine.
+The web server binds to localhost only by default.`
+
+	EnvServeUsage = "serve"
+	EnvServeShort = "Start the environment manager web UI"
+	EnvServeLong  = `Start a local web server for managing environment groups,
+variables, and templates. Data is stored in SQLite under your user config directory.`
+
+	EnvResetUsage = "reset"
+	EnvResetShort = "Delete local env manager database (requires confirmation)"
+	EnvResetLong  = `Permanently delete the local SQLite database and all stored
+environments, variables, and templates.
+
+You must type an 8-character random code shown in the terminal to confirm.
+Stop "elsa env serve" before resetting if the database is in use.`
+
+	DefaultEnvHost = "127.0.0.1"
+	DefaultEnvPort = "1999"
+
+	EnvFlagHost      = "host"
+	EnvFlagPort      = "port"
+	EnvFlagDB        = "db"
+	EnvFlagNoBrowser = "no-browser"
+
+	EnvFlagHostUsage      = "Host to bind (use 127.0.0.1 to keep data local)"
+	EnvFlagPortUsage      = "Port for the web server"
+	EnvFlagDBUsage        = "Path to SQLite database (default: user config dir)"
+	EnvFlagNoBrowserUsage = "Do not open the system browser automatically"
+
+	MsgEnvStarting   = "🌐 Elsa Env Manager: %s"
+	MsgEnvDatabase   = "📁 Database: %s"
+	MsgEnvPressCtrlC = "Press Ctrl+C to stop"
+
+	MsgEnvResetWarning  = "⚠️  WARNING: This will permanently delete ALL env manager data."
+	MsgEnvResetDatabase = "Database: %s"
+	MsgEnvResetTypeCode = "Type this exact code to confirm (8 letters/digits, case-sensitive):\n%s"
+	MsgEnvResetPrompt   = "> "
+	MsgEnvResetAborted  = "Reset aborted — confirmation code did not match."
+	MsgEnvResetSuccess  = "✅ Database deleted: %s"
+	MsgEnvResetInUseHint = "💡 The database is still open. Press Ctrl+C in the terminal running \"elsa env serve\", then run reset again."
+
+	ErrEnvResetMismatch = "confirmation code did not match"
+)

--- a/internal/envmanager/browser.go
+++ b/internal/envmanager/browser.go
@@ -1,0 +1,56 @@
+package envmanager
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"os/exec"
+	"runtime"
+	"time"
+)
+
+// BrowserURL returns a URL suitable for opening in the system browser.
+func BrowserURL(host, port string) string {
+	h := host
+	if h == "" || h == "0.0.0.0" || h == "::" || h == "[::]" {
+		h = "127.0.0.1"
+	}
+	return "http://" + net.JoinHostPort(h, port)
+}
+
+// WaitForServer polls until the HTTP server responds or timeout elapses.
+func WaitForServer(url string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	client := &http.Client{Timeout: 500 * time.Millisecond}
+	for time.Now().Before(deadline) {
+		resp, err := client.Get(url)
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode < 500 {
+				return true
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return false
+}
+
+// OpenBrowser opens url in the default system browser.
+func OpenBrowser(url string) error {
+	switch runtime.GOOS {
+	case "windows":
+		return exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
+	case "darwin":
+		return exec.Command("open", url).Start()
+	default:
+		return exec.Command("xdg-open", url).Start()
+	}
+}
+
+// OpenBrowserWhenReady waits for the server then opens the browser.
+func OpenBrowserWhenReady(url string) error {
+	if !WaitForServer(url, 8*time.Second) {
+		return fmt.Errorf("server did not become ready in time")
+	}
+	return OpenBrowser(url)
+}

--- a/internal/envmanager/db.go
+++ b/internal/envmanager/db.go
@@ -1,0 +1,40 @@
+package envmanager
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// DefaultDBPath returns the default SQLite path under user config dir
+func DefaultDBPath() (string, error) {
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve config dir: %w", err)
+	}
+	dir := filepath.Join(configDir, "elsa")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("create config dir: %w", err)
+	}
+	return filepath.Join(dir, "elsaenvmanager.db"), nil
+}
+
+// OpenDB opens (or creates) the SQLite database and runs migrations
+func OpenDB(path string) (*gorm.DB, error) {
+	db, err := gorm.Open(sqlite.Open(path), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("open database: %w", err)
+	}
+
+	if err := db.AutoMigrate(&Environment{}, &Variable{}, &Value{}, &Template{}); err != nil {
+		return nil, fmt.Errorf("migrate database: %w", err)
+	}
+
+	return db, nil
+}

--- a/internal/envmanager/embed.go
+++ b/internal/envmanager/embed.go
@@ -1,0 +1,6 @@
+package envmanager
+
+import "embed"
+
+//go:embed web/*
+var WebFS embed.FS

--- a/internal/envmanager/models.go
+++ b/internal/envmanager/models.go
@@ -1,0 +1,76 @@
+package envmanager
+
+import "time"
+
+// Environment is a named group (local, staging, production, etc.)
+type Environment struct {
+	ID        uint      `json:"id" gorm:"primaryKey"`
+	Name      string    `json:"name" gorm:"uniqueIndex;not null"`
+	SortOrder int       `json:"sort_order"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// Variable is an env key shared across selected environments
+type Variable struct {
+	ID          uint      `json:"id" gorm:"primaryKey"`
+	Key         string    `json:"key" gorm:"uniqueIndex;not null"`
+	Description string    `json:"description"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+// Value stores the value of a variable for a specific environment
+type Value struct {
+	ID            uint   `json:"id" gorm:"primaryKey"`
+	VariableID    uint   `json:"variable_id" gorm:"not null;uniqueIndex:idx_var_env"`
+	EnvironmentID uint   `json:"environment_id" gorm:"not null;uniqueIndex:idx_var_env"`
+	Value         string `json:"value"`
+}
+
+// Template stores a Go text/template body for export
+type Template struct {
+	ID        uint      `json:"id" gorm:"primaryKey"`
+	Name      string    `json:"name" gorm:"uniqueIndex;not null"`
+	Body      string    `json:"body" gorm:"type:text;not null"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// VariablePayload is used for create/update API requests
+type VariablePayload struct {
+	Key          string         `json:"key"`
+	Description  string         `json:"description"`
+	EnvironmentIDs []uint       `json:"environment_ids"`
+	Values       []ValuePayload `json:"values"`
+}
+
+type ValuePayload struct {
+	EnvironmentID uint   `json:"environment_id"`
+	Value         string `json:"value"`
+}
+
+// VariableDetail includes values per environment for API responses
+type VariableDetail struct {
+	Variable
+	EnvironmentIDs []uint        `json:"environment_ids"`
+	Values         []ValueDetail `json:"values"`
+}
+
+type ValueDetail struct {
+	EnvironmentID   uint   `json:"environment_id"`
+	EnvironmentName string `json:"environment_name"`
+	Value             string `json:"value"`
+}
+
+// RenderRequest for template / env export
+type RenderRequest struct {
+	EnvironmentID uint   `json:"environment_id"`
+	Filename      string `json:"filename"`
+}
+
+// RenderResponse holds generated content
+type RenderResponse struct {
+	Content  string `json:"content"`
+	Filename string `json:"filename"`
+}

--- a/internal/envmanager/render.go
+++ b/internal/envmanager/render.go
@@ -1,0 +1,42 @@
+package envmanager
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"text/template"
+)
+
+// RenderTemplate executes a Go text/template with environment values.
+// Keys in the data map match variable names; use {{.DB_HOST}} in templates.
+func RenderTemplate(body string, data map[string]string) (string, error) {
+	body = strings.TrimSpace(body)
+	if body == "" {
+		return "", fmt.Errorf("template body is empty")
+	}
+
+	tmpl, err := template.New("env").Option("missingkey=zero").Parse(body)
+	if err != nil {
+		return "", fmt.Errorf("parse template: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("execute template: %w", err)
+	}
+	return buf.String(), nil
+}
+
+// DefaultFilename returns a sensible export filename
+func DefaultFilename(envName string) string {
+	safe := strings.Map(func(r rune) rune {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' {
+			return r
+		}
+		return '_'
+	}, strings.ToLower(strings.TrimSpace(envName)))
+	if safe == "" {
+		safe = "environment"
+	}
+	return "." + safe + ".env"
+}

--- a/internal/envmanager/render_test.go
+++ b/internal/envmanager/render_test.go
@@ -1,0 +1,25 @@
+package envmanager
+
+import "testing"
+
+func TestRenderTemplate(t *testing.T) {
+	body := "DB_HOST={{.DB_HOST}}\nDB_USER={{.DB_USER}}"
+	data := map[string]string{
+		"DB_HOST": "localhost",
+		"DB_USER": "admin",
+	}
+	out, err := RenderTemplate(body, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "DB_HOST=localhost\nDB_USER=admin"
+	if out != want {
+		t.Fatalf("got %q, want %q", out, want)
+	}
+}
+
+func TestDefaultFilename(t *testing.T) {
+	if got := DefaultFilename("Staging"); got != ".staging.env" {
+		t.Fatalf("got %q", got)
+	}
+}

--- a/internal/envmanager/reset.go
+++ b/internal/envmanager/reset.go
@@ -1,0 +1,83 @@
+package envmanager
+
+import (
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"math/big"
+	"os"
+	"strings"
+)
+
+// ErrDatabaseInUse is returned when the SQLite file is locked by another process.
+var ErrDatabaseInUse = errors.New("database file is in use by another process")
+
+const confirmCharset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+// GenerateConfirmCode returns a random alphanumeric code (letters and digits only).
+func GenerateConfirmCode(length int) (string, error) {
+	if length <= 0 {
+		return "", fmt.Errorf("code length must be positive")
+	}
+	code := make([]byte, length)
+	max := big.NewInt(int64(len(confirmCharset)))
+	for i := 0; i < length; i++ {
+		n, err := rand.Int(rand.Reader, max)
+		if err != nil {
+			return "", err
+		}
+		code[i] = confirmCharset[n.Int64()]
+	}
+	return string(code), nil
+}
+
+func isFileInUse(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "being used by another process") ||
+		strings.Contains(msg, "used by another process") ||
+		strings.Contains(msg, "resource busy") ||
+		strings.Contains(msg, "database is locked")
+}
+
+// CheckDatabaseNotInUse returns an error if the database file exists but cannot be opened for write.
+func CheckDatabaseNotInUse(path string) error {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return nil
+	}
+	f, err := os.OpenFile(path, os.O_RDWR, 0o600)
+	if err != nil {
+		if isFileInUse(err) {
+			return fmt.Errorf("%w (stop \"elsa env serve\" with Ctrl+C, then run reset again)", ErrDatabaseInUse)
+		}
+		return err
+	}
+	return f.Close()
+}
+
+// DeleteDatabase removes the SQLite database and related WAL/SHM files.
+func DeleteDatabase(path string) error {
+	if err := CheckDatabaseNotInUse(path); err != nil {
+		return err
+	}
+
+	removed := false
+	for _, p := range []string{path, path + "-wal", path + "-shm"} {
+		if err := os.Remove(p); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			if isFileInUse(err) {
+				return fmt.Errorf("%w: close \"elsa env serve\" or any app using %s, then retry", ErrDatabaseInUse, path)
+			}
+			return fmt.Errorf("remove %s: %w", p, err)
+		}
+		removed = true
+	}
+	if !removed {
+		return fmt.Errorf("database not found: %s", path)
+	}
+	return nil
+}

--- a/internal/envmanager/reset_test.go
+++ b/internal/envmanager/reset_test.go
@@ -1,0 +1,37 @@
+package envmanager
+
+import (
+	"os"
+	"regexp"
+	"testing"
+)
+
+func TestGenerateConfirmCode(t *testing.T) {
+	code, err := GenerateConfirmCode(8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(code) != 8 {
+		t.Fatalf("got length %d", len(code))
+	}
+	if !regexp.MustCompile(`^[a-zA-Z0-9]{8}$`).MatchString(code) {
+		t.Fatalf("invalid charset: %q", code)
+	}
+}
+
+func TestDeleteDatabase(t *testing.T) {
+	path := t.TempDir() + "/elsaenvmanager.db"
+	db, err := OpenDB(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sqlDB, _ := db.DB()
+	_ = sqlDB.Close()
+
+	if err := DeleteDatabase(path); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatal("expected db removed")
+	}
+}

--- a/internal/envmanager/server.go
+++ b/internal/envmanager/server.go
@@ -1,0 +1,454 @@
+package envmanager
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// Server serves the env manager API and embedded web UI
+type Server struct {
+	store  *Store
+	mux    *http.ServeMux
+	static fs.FS
+}
+
+func NewServer(store *Store) (*Server, error) {
+	sub, err := fs.Sub(WebFS, "web")
+	if err != nil {
+		return nil, err
+	}
+
+	s := &Server{
+		store:  store,
+		mux:    http.NewServeMux(),
+		static: sub,
+	}
+	s.routes()
+	return s, nil
+}
+
+func (s *Server) Handler() http.Handler {
+	return s.mux
+}
+
+func (s *Server) routes() {
+	s.mux.HandleFunc("/", s.handleIndex)
+	s.mux.Handle("/static/", http.StripPrefix("/static/", http.FileServer(http.FS(s.static))))
+
+	s.mux.HandleFunc("/api/environments", s.handleEnvironments)
+	s.mux.HandleFunc("/api/environments/", s.handleEnvironmentByID)
+	s.mux.HandleFunc("/api/variables", s.handleVariables)
+	s.mux.HandleFunc("/api/variables/", s.handleVariableByID)
+	s.mux.HandleFunc("/api/templates", s.handleTemplates)
+	s.mux.HandleFunc("/api/templates/", s.handleTemplateByID)
+}
+
+func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+	data, err := fs.ReadFile(s.static, "index.html")
+	if err != nil {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = w.Write(data)
+}
+
+// --- environments ---
+
+func (s *Server) handleEnvironments(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		envs, err := s.store.ListEnvironments()
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, envs)
+	case http.MethodPost:
+		var req struct {
+			Name      string `json:"name"`
+			SortOrder int    `json:"sort_order"`
+		}
+		if err := readJSON(r, &req); err != nil {
+			writeError(w, http.StatusBadRequest, err)
+			return
+		}
+		env, err := s.store.CreateEnvironment(req.Name, req.SortOrder)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, err)
+			return
+		}
+		writeJSON(w, http.StatusCreated, env)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (s *Server) handleEnvironmentByID(w http.ResponseWriter, r *http.Request) {
+	id, action, ok := parseSubPath(r.URL.Path, "/api/environments/")
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+
+	if action == "export" {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		s.handleExportEnv(w, r, id)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPut:
+		var req struct {
+			Name      string `json:"name"`
+			SortOrder int    `json:"sort_order"`
+		}
+		if err := readJSON(r, &req); err != nil {
+			writeError(w, http.StatusBadRequest, err)
+			return
+		}
+		env, err := s.store.UpdateEnvironment(id, req.Name, req.SortOrder)
+		if err != nil {
+			status := http.StatusInternalServerError
+			if errors.Is(err, ErrNotFound) {
+				status = http.StatusNotFound
+			}
+			writeError(w, status, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, env)
+	case http.MethodDelete:
+		if err := s.store.DeleteEnvironment(id); err != nil {
+			status := http.StatusInternalServerError
+			if errors.Is(err, ErrNotFound) {
+				status = http.StatusNotFound
+			}
+			writeError(w, status, err)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (s *Server) handleExportEnv(w http.ResponseWriter, r *http.Request, envID uint) {
+	content, err := s.store.ExportDotEnv(envID)
+	if err != nil {
+		status := http.StatusInternalServerError
+		if errors.Is(err, ErrNotFound) {
+			status = http.StatusNotFound
+		}
+		writeError(w, status, err)
+		return
+	}
+
+	envs, _ := s.store.ListEnvironments()
+	filename := ".env"
+	for _, e := range envs {
+		if e.ID == envID {
+			filename = DefaultFilename(e.Name)
+			break
+		}
+	}
+
+	var req struct {
+		Filename string `json:"filename"`
+	}
+	_ = readJSONOptional(r, &req)
+	if strings.TrimSpace(req.Filename) != "" {
+		filename = req.Filename
+	}
+
+	writeJSON(w, http.StatusOK, RenderResponse{Content: content, Filename: filename})
+}
+
+// --- variables ---
+
+func (s *Server) handleVariables(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		vars, err := s.store.ListVariables()
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, vars)
+	case http.MethodPost:
+		var payload VariablePayload
+		if err := readJSON(r, &payload); err != nil {
+			writeError(w, http.StatusBadRequest, err)
+			return
+		}
+		v, err := s.store.CreateVariable(payload)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, err)
+			return
+		}
+		writeJSON(w, http.StatusCreated, v)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (s *Server) handleVariableByID(w http.ResponseWriter, r *http.Request) {
+	id, _, ok := parseSubPath(r.URL.Path, "/api/variables/")
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		v, err := s.store.GetVariable(id)
+		if err != nil {
+			status := http.StatusInternalServerError
+			if errors.Is(err, ErrNotFound) {
+				status = http.StatusNotFound
+			}
+			writeError(w, status, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, v)
+	case http.MethodPut:
+		var payload VariablePayload
+		if err := readJSON(r, &payload); err != nil {
+			writeError(w, http.StatusBadRequest, err)
+			return
+		}
+		v, err := s.store.UpdateVariable(id, payload)
+		if err != nil {
+			status := http.StatusBadRequest
+			if errors.Is(err, ErrNotFound) {
+				status = http.StatusNotFound
+			}
+			writeError(w, status, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, v)
+	case http.MethodDelete:
+		if err := s.store.DeleteVariable(id); err != nil {
+			status := http.StatusInternalServerError
+			if errors.Is(err, ErrNotFound) {
+				status = http.StatusNotFound
+			}
+			writeError(w, status, err)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+// --- templates ---
+
+func (s *Server) handleTemplates(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		list, err := s.store.ListTemplates()
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, list)
+	case http.MethodPost:
+		var req struct {
+			Name string `json:"name"`
+			Body string `json:"body"`
+		}
+		if err := readJSON(r, &req); err != nil {
+			writeError(w, http.StatusBadRequest, err)
+			return
+		}
+		t, err := s.store.CreateTemplate(req.Name, req.Body)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, err)
+			return
+		}
+		writeJSON(w, http.StatusCreated, t)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (s *Server) handleTemplateByID(w http.ResponseWriter, r *http.Request) {
+	id, action, ok := parseSubPath(r.URL.Path, "/api/templates/")
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+
+	if action == "render" {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		s.handleRenderTemplate(w, r, id)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		t, err := s.store.GetTemplate(id)
+		if err != nil {
+			status := http.StatusInternalServerError
+			if errors.Is(err, ErrNotFound) {
+				status = http.StatusNotFound
+			}
+			writeError(w, status, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, t)
+	case http.MethodPut:
+		var req struct {
+			Name string `json:"name"`
+			Body string `json:"body"`
+		}
+		if err := readJSON(r, &req); err != nil {
+			writeError(w, http.StatusBadRequest, err)
+			return
+		}
+		t, err := s.store.UpdateTemplate(id, req.Name, req.Body)
+		if err != nil {
+			status := http.StatusBadRequest
+			if errors.Is(err, ErrNotFound) {
+				status = http.StatusNotFound
+			}
+			writeError(w, status, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, t)
+	case http.MethodDelete:
+		if err := s.store.DeleteTemplate(id); err != nil {
+			status := http.StatusInternalServerError
+			if errors.Is(err, ErrNotFound) {
+				status = http.StatusNotFound
+			}
+			writeError(w, status, err)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (s *Server) handleRenderTemplate(w http.ResponseWriter, r *http.Request, templateID uint) {
+	var req RenderRequest
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+
+	t, err := s.store.GetTemplate(templateID)
+	if err != nil {
+		status := http.StatusInternalServerError
+		if errors.Is(err, ErrNotFound) {
+			status = http.StatusNotFound
+		}
+		writeError(w, status, err)
+		return
+	}
+
+	data, err := s.store.EnvMap(req.EnvironmentID)
+	if err != nil {
+		status := http.StatusInternalServerError
+		if errors.Is(err, ErrNotFound) {
+			status = http.StatusNotFound
+		}
+		writeError(w, status, err)
+		return
+	}
+
+	content, err := RenderTemplate(t.Body, data)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+
+	filename := strings.TrimSpace(req.Filename)
+	if filename == "" {
+		envs, _ := s.store.ListEnvironments()
+		for _, e := range envs {
+			if e.ID == req.EnvironmentID {
+				filename = DefaultFilename(e.Name)
+				break
+			}
+		}
+		if filename == "" {
+			filename = ".env"
+		}
+	}
+
+	writeJSON(w, http.StatusOK, RenderResponse{Content: content, Filename: filename})
+}
+
+func parseSubPath(path, prefix string) (id uint, action string, ok bool) {
+	rest := strings.TrimPrefix(path, prefix)
+	rest = strings.TrimSuffix(rest, "/")
+	if rest == "" {
+		return 0, "", false
+	}
+	parts := strings.Split(rest, "/")
+	n, err := strconv.ParseUint(parts[0], 10, 64)
+	if err != nil {
+		return 0, "", false
+	}
+	if len(parts) > 1 {
+		return uint(n), parts[1], true
+	}
+	return uint(n), "", true
+}
+
+func readJSON(r *http.Request, v any) error {
+	if r.Body == nil {
+		return fmt.Errorf("empty body")
+	}
+	defer r.Body.Close()
+	dec := json.NewDecoder(io.LimitReader(r.Body, 1<<20))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(v); err != nil {
+		return err
+	}
+	return nil
+}
+
+func readJSONOptional(r *http.Request, v any) error {
+	if r.Body == nil {
+		return nil
+	}
+	defer r.Body.Close()
+	data, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	if err != nil {
+		return err
+	}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return nil
+	}
+	return json.Unmarshal(data, v)
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func writeError(w http.ResponseWriter, status int, err error) {
+	writeJSON(w, status, map[string]string{"error": err.Error()})
+}

--- a/internal/envmanager/store.go
+++ b/internal/envmanager/store.go
@@ -1,0 +1,378 @@
+package envmanager
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"gorm.io/gorm"
+)
+
+var ErrNotFound = errors.New("not found")
+
+// Store wraps database operations for the env manager
+type Store struct {
+	db *gorm.DB
+}
+
+func NewStore(db *gorm.DB) *Store {
+	return &Store{db: db}
+}
+
+// --- Environments ---
+
+func (s *Store) ListEnvironments() ([]Environment, error) {
+	var envs []Environment
+	err := s.db.Order("sort_order asc, name asc").Find(&envs).Error
+	return envs, err
+}
+
+func (s *Store) CreateEnvironment(name string, sortOrder int) (*Environment, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil, fmt.Errorf("name is required")
+	}
+	env := &Environment{Name: name, SortOrder: sortOrder}
+	if err := s.db.Create(env).Error; err != nil {
+		return nil, err
+	}
+	return env, nil
+}
+
+func (s *Store) UpdateEnvironment(id uint, name string, sortOrder int) (*Environment, error) {
+	var env Environment
+	if err := s.db.First(&env, id).Error; err != nil {
+		return nil, ErrNotFound
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil, fmt.Errorf("name is required")
+	}
+	env.Name = name
+	env.SortOrder = sortOrder
+	if err := s.db.Save(&env).Error; err != nil {
+		return nil, err
+	}
+	return &env, nil
+}
+
+func (s *Store) DeleteEnvironment(id uint) error {
+	return s.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("environment_id = ?", id).Delete(&Value{}).Error; err != nil {
+			return err
+		}
+		res := tx.Delete(&Environment{}, id)
+		if res.Error != nil {
+			return res.Error
+		}
+		if res.RowsAffected == 0 {
+			return ErrNotFound
+		}
+		return nil
+	})
+}
+
+// --- Variables ---
+
+func (s *Store) ListVariables() ([]VariableDetail, error) {
+	var vars []Variable
+	if err := s.db.Order("key asc").Find(&vars).Error; err != nil {
+		return nil, err
+	}
+
+	result := make([]VariableDetail, 0, len(vars))
+	for _, v := range vars {
+		detail, err := s.getVariableDetail(v)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, *detail)
+	}
+	return result, nil
+}
+
+func (s *Store) GetVariable(id uint) (*VariableDetail, error) {
+	var v Variable
+	if err := s.db.First(&v, id).Error; err != nil {
+		return nil, ErrNotFound
+	}
+	return s.getVariableDetail(v)
+}
+
+func (s *Store) getVariableDetail(v Variable) (*VariableDetail, error) {
+	var values []Value
+	if err := s.db.Where("variable_id = ?", v.ID).Find(&values).Error; err != nil {
+		return nil, err
+	}
+
+	envIDs := make([]uint, 0, len(values))
+	valueDetails := make([]ValueDetail, 0, len(values))
+
+	for _, val := range values {
+		var env Environment
+		if err := s.db.First(&env, val.EnvironmentID).Error; err != nil {
+			continue
+		}
+		envIDs = append(envIDs, val.EnvironmentID)
+		valueDetails = append(valueDetails, ValueDetail{
+			EnvironmentID:   val.EnvironmentID,
+			EnvironmentName: env.Name,
+			Value:           val.Value,
+		})
+	}
+
+	return &VariableDetail{
+		Variable:       v,
+		EnvironmentIDs: envIDs,
+		Values:         valueDetails,
+	}, nil
+}
+
+func (s *Store) CreateVariable(payload VariablePayload) (*VariableDetail, error) {
+	key := strings.TrimSpace(payload.Key)
+	if key == "" {
+		return nil, fmt.Errorf("key is required")
+	}
+
+	var detail *VariableDetail
+	err := s.db.Transaction(func(tx *gorm.DB) error {
+		v := &Variable{Key: key, Description: strings.TrimSpace(payload.Description)}
+		if err := tx.Create(v).Error; err != nil {
+			return err
+		}
+		if err := s.syncValues(tx, v.ID, payload); err != nil {
+			return err
+		}
+		store := &Store{db: tx}
+		var err error
+		detail, err = store.getVariableDetail(*v)
+		return err
+	})
+	return detail, err
+}
+
+func (s *Store) UpdateVariable(id uint, payload VariablePayload) (*VariableDetail, error) {
+	key := strings.TrimSpace(payload.Key)
+	if key == "" {
+		return nil, fmt.Errorf("key is required")
+	}
+
+	var detail *VariableDetail
+	err := s.db.Transaction(func(tx *gorm.DB) error {
+		var v Variable
+		if err := tx.First(&v, id).Error; err != nil {
+			return ErrNotFound
+		}
+		v.Key = key
+		v.Description = strings.TrimSpace(payload.Description)
+		if err := tx.Save(&v).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("variable_id = ?", id).Delete(&Value{}).Error; err != nil {
+			return err
+		}
+		if err := s.syncValues(tx, id, payload); err != nil {
+			return err
+		}
+		store := &Store{db: tx}
+		var err error
+		detail, err = store.getVariableDetail(v)
+		return err
+	})
+	return detail, err
+}
+
+func (s *Store) syncValues(tx *gorm.DB, variableID uint, payload VariablePayload) error {
+	seen := make(map[uint]bool)
+	for _, vp := range payload.Values {
+		if !containsUint(payload.EnvironmentIDs, vp.EnvironmentID) {
+			continue
+		}
+		if seen[vp.EnvironmentID] {
+			continue
+		}
+		seen[vp.EnvironmentID] = true
+		val := &Value{
+			VariableID:    variableID,
+			EnvironmentID: vp.EnvironmentID,
+			Value:         vp.Value,
+		}
+		if err := tx.Create(val).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Store) DeleteVariable(id uint) error {
+	return s.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("variable_id = ?", id).Delete(&Value{}).Error; err != nil {
+			return err
+		}
+		res := tx.Delete(&Variable{}, id)
+		if res.Error != nil {
+			return res.Error
+		}
+		if res.RowsAffected == 0 {
+			return ErrNotFound
+		}
+		return nil
+	})
+}
+
+// EnvMap returns all key-value pairs for an environment (for templates / export)
+func (s *Store) EnvMap(environmentID uint) (map[string]string, error) {
+	var env Environment
+	if err := s.db.First(&env, environmentID).Error; err != nil {
+		return nil, ErrNotFound
+	}
+
+	var values []Value
+	if err := s.db.Where("environment_id = ?", environmentID).Find(&values).Error; err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]string)
+	for _, val := range values {
+		var v Variable
+		if err := s.db.First(&v, val.VariableID).Error; err != nil {
+			continue
+		}
+		result[v.Key] = val.Value
+	}
+	return result, nil
+}
+
+// ExportDotEnv generates KEY=value lines for one environment
+func (s *Store) ExportDotEnv(environmentID uint) (string, error) {
+	m, err := s.EnvMap(environmentID)
+	if err != nil {
+		return "", err
+	}
+
+	vars, err := s.ListVariables()
+	if err != nil {
+		return "", err
+	}
+
+	var b strings.Builder
+	for _, vd := range vars {
+		val, ok := m[vd.Key]
+		if !ok {
+			continue
+		}
+		b.WriteString(formatDotEnvLine(vd.Key, val))
+		b.WriteByte('\n')
+	}
+	return strings.TrimRight(b.String(), "\n"), nil
+}
+
+func formatDotEnvLine(key, value string) string {
+	if needsQuotes(value) {
+		escaped := strings.ReplaceAll(value, `"`, `\"`)
+		return fmt.Sprintf("%s=\"%s\"", key, escaped)
+	}
+	return fmt.Sprintf("%s=%s", key, value)
+}
+
+func needsQuotes(value string) bool {
+	return strings.ContainsAny(value, " #\t\n\"'\\")
+}
+
+// --- Templates ---
+
+func (s *Store) templateNameExists(name string, excludeID uint) (bool, error) {
+	name = strings.TrimSpace(name)
+	var count int64
+	q := s.db.Model(&Template{}).Where("LOWER(name) = LOWER(?)", name)
+	if excludeID > 0 {
+		q = q.Where("id <> ?", excludeID)
+	}
+	if err := q.Count(&count).Error; err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
+func (s *Store) ListTemplates() ([]Template, error) {
+	var templates []Template
+	err := s.db.Order("name asc").Find(&templates).Error
+	return templates, err
+}
+
+func (s *Store) GetTemplate(id uint) (*Template, error) {
+	var t Template
+	if err := s.db.First(&t, id).Error; err != nil {
+		return nil, ErrNotFound
+	}
+	return &t, nil
+}
+
+func (s *Store) CreateTemplate(name, body string) (*Template, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil, fmt.Errorf("template name is required")
+	}
+	if strings.TrimSpace(body) == "" {
+		return nil, fmt.Errorf("template body is required")
+	}
+	taken, err := s.templateNameExists(name, 0)
+	if err != nil {
+		return nil, err
+	}
+	if taken {
+		return nil, fmt.Errorf("template name %q already exists", name)
+	}
+	t := &Template{Name: name, Body: body}
+	if err := s.db.Create(t).Error; err != nil {
+		return nil, err
+	}
+	return t, nil
+}
+
+func (s *Store) UpdateTemplate(id uint, name, body string) (*Template, error) {
+	var t Template
+	if err := s.db.First(&t, id).Error; err != nil {
+		return nil, ErrNotFound
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil, fmt.Errorf("template name is required")
+	}
+	if strings.TrimSpace(body) == "" {
+		return nil, fmt.Errorf("template body is required")
+	}
+	taken, err := s.templateNameExists(name, id)
+	if err != nil {
+		return nil, err
+	}
+	if taken {
+		return nil, fmt.Errorf("template name %q already exists", name)
+	}
+	t.Name = name
+	t.Body = body
+	if err := s.db.Save(&t).Error; err != nil {
+		return nil, err
+	}
+	return &t, nil
+}
+
+func (s *Store) DeleteTemplate(id uint) error {
+	res := s.db.Delete(&Template{}, id)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func containsUint(slice []uint, id uint) bool {
+	for _, v := range slice {
+		if v == id {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/envmanager/store_template_test.go
+++ b/internal/envmanager/store_template_test.go
@@ -1,0 +1,30 @@
+package envmanager
+
+import (
+	"testing"
+)
+
+func TestTemplateNameUnique(t *testing.T) {
+	path := t.TempDir() + "/test.db"
+	db, err := OpenDB(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+
+	store := NewStore(db)
+
+	if _, err := store.CreateTemplate("My Template", "x={{.X}}"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.CreateTemplate("my template", "y={{.Y}}"); err == nil {
+		t.Fatal("expected duplicate name error")
+	}
+	if _, err := store.CreateTemplate("other", ""); err == nil {
+		t.Fatal("expected empty body error")
+	}
+}

--- a/internal/envmanager/web/app.css
+++ b/internal/envmanager/web/app.css
@@ -1,0 +1,646 @@
+:root {
+  --bg: #0d1117;
+  --bg-elevated: #161b22;
+  --bg-card: #1c2128;
+  --border: #30363d;
+  --text: #e6edf3;
+  --text-muted: #8b949e;
+  --accent: #58a6ff;
+  --accent-dim: #388bfd66;
+  --danger: #f85149;
+  --success: #3fb950;
+  --radius: 10px;
+  --shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  --font: "Segoe UI", system-ui, -apple-system, sans-serif;
+  --mono: "Cascadia Code", "Fira Code", Consolas, monospace;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  min-height: 100%;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font);
+  line-height: 1.5;
+}
+
+code {
+  font-family: var(--mono);
+  font-size: 0.9em;
+  background: var(--bg-elevated);
+  padding: 0.15em 0.4em;
+  border-radius: 4px;
+}
+
+.app {
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  grid-template-rows: auto 1fr;
+  min-height: 100vh;
+}
+
+.header {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-elevated);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.logo {
+  font-size: 1.5rem;
+  color: var(--accent);
+}
+
+.brand h1 {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 600;
+}
+
+.tagline {
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.nav-toggle {
+  display: none;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--radius);
+  cursor: pointer;
+}
+
+.nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 1rem;
+  border-right: 1px solid var(--border);
+  background: var(--bg-elevated);
+}
+
+.nav-item {
+  text-align: left;
+  padding: 0.65rem 1rem;
+  border: none;
+  border-radius: var(--radius);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 0.95rem;
+  transition: background 0.15s, color 0.15s;
+}
+
+.nav-item:hover { background: var(--bg-card); color: var(--text); }
+.nav-item.active {
+  background: var(--accent-dim);
+  color: var(--accent);
+  font-weight: 500;
+}
+
+.main {
+  padding: 1.25rem 1.5rem 2rem;
+  overflow-x: hidden;
+}
+
+.page { display: none; }
+.page.active { display: block; }
+
+.page-header { margin-bottom: 1.25rem; }
+.page-header h2 { margin: 0 0 0.35rem; font-size: 1.35rem; }
+.page-header p { margin: 0; color: var(--text-muted); font-size: 0.9rem; }
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+
+.form-inline {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+input, textarea, select {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--text);
+  border-radius: var(--radius);
+  padding: 0.55rem 0.75rem;
+  font: inherit;
+  width: 100%;
+}
+
+input:focus, textarea:focus, select:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-dim);
+}
+
+textarea { font-family: var(--mono); font-size: 0.85rem; resize: vertical; }
+
+.form-inline input[type="text"] { flex: 1; min-width: 140px; }
+.form-inline input[type="number"] { width: 80px; }
+
+label {
+  display: block;
+  margin-bottom: 0.85rem;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+label input, label textarea, label select { margin-top: 0.35rem; }
+
+.field-hint {
+  display: block;
+  margin-top: 0.3rem;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.btn {
+  padding: 0.55rem 1rem;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  background: var(--bg-card);
+  color: var(--text);
+  cursor: pointer;
+  font-size: 0.9rem;
+  white-space: nowrap;
+}
+
+.btn:hover { border-color: var(--text-muted); }
+.btn.primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+  font-weight: 500;
+}
+.btn.primary:hover { filter: brightness(1.1); }
+.btn.danger { color: var(--danger); border-color: var(--danger); }
+.btn.icon { padding: 0.35rem 0.5rem; background: transparent; }
+.btn.small { padding: 0.35rem 0.65rem; font-size: 0.8rem; }
+.btn:disabled { opacity: 0.45; cursor: not-allowed; }
+
+.list { display: flex; flex-direction: column; gap: 0.65rem; }
+
+.list-item {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.85rem 1rem;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+.list-item .meta { flex: 1; min-width: 120px; }
+.list-item .title { font-weight: 500; }
+.list-item .sub { font-size: 0.8rem; color: var(--text-muted); }
+
+.list-item .actions { display: flex; flex-wrap: wrap; gap: 0.35rem; }
+
+/* Templates list */
+.tpl-new-btn { margin-bottom: 1.25rem; }
+
+.template-list { gap: 1rem; }
+
+.template-item {
+  align-items: flex-start;
+  gap: 1.5rem;
+  padding: 1.25rem 1.5rem;
+}
+
+.template-meta {
+  flex: 1;
+  min-width: 0;
+  padding-right: 1rem;
+}
+
+.template-title {
+  font-weight: 600;
+  font-size: 1rem;
+  margin-bottom: 0.65rem;
+}
+
+.template-preview {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  font-family: var(--mono);
+  font-size: 0.8rem;
+  line-height: 1.5;
+  color: var(--text-muted);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 4.5em;
+  overflow: hidden;
+}
+
+.template-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  flex-shrink: 0;
+  padding-top: 0.15rem;
+  min-width: 88px;
+}
+
+.template-actions .btn { width: 100%; justify-content: center; }
+
+.empty {
+  text-align: center;
+  padding: 2rem;
+  color: var(--text-muted);
+  border: 1px dashed var(--border);
+  border-radius: var(--radius);
+}
+
+.checks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+}
+
+.checks label {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin: 0;
+  color: var(--text);
+  cursor: pointer;
+}
+
+.checks input { width: auto; margin: 0; }
+
+.value-field {
+  margin-top: 0.5rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--border);
+}
+
+.value-field span {
+  display: block;
+  font-size: 0.8rem;
+  color: var(--accent);
+  margin-bottom: 0.25rem;
+}
+
+.modal {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 0;
+  background: var(--bg-elevated);
+  color: var(--text);
+  max-width: min(560px, 96vw);
+  width: 100%;
+  box-shadow: var(--shadow);
+}
+
+.modal::backdrop { background: rgba(0, 0, 0, 0.65); }
+
+.modal-header, .modal-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.modal-footer { border-bottom: none; border-top: 1px solid var(--border); gap: 0.5rem; }
+.modal-body { padding: 1rem 1.25rem; max-height: 70vh; overflow-y: auto; }
+.modal-header h3 { margin: 0; font-size: 1.1rem; }
+
+.preview {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1rem;
+  font-family: var(--mono);
+  font-size: 0.8rem;
+  white-space: pre-wrap;
+  word-break: break-all;
+  max-height: 240px;
+  overflow: auto;
+  margin: 0;
+}
+
+.preview-label { margin-top: 1rem; }
+
+.toast {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  padding: 0.75rem 1.25rem;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  z-index: 100;
+}
+
+.toast.success { border-color: var(--success); }
+.toast.error { border-color: var(--danger); }
+
+.badge {
+  display: inline-block;
+  font-size: 0.7rem;
+  padding: 0.15rem 0.45rem;
+  border-radius: 999px;
+  background: var(--accent-dim);
+  color: var(--accent);
+  margin-right: 0.25rem;
+}
+
+/* Variables table */
+.var-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem 1rem;
+  margin-bottom: 1rem;
+}
+
+.var-search {
+  flex: 1;
+  min-width: 180px;
+  max-width: 320px;
+  width: auto;
+}
+
+/* Environment column dropdown (fixed width) */
+.env-columns-wrap {
+  position: relative;
+  flex-shrink: 0;
+}
+
+.env-columns-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 200px;
+  max-width: 280px;
+  justify-content: space-between;
+}
+
+.env-columns-label {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.env-columns-summary {
+  flex: 1;
+  text-align: left;
+  font-size: 0.85rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.env-columns-btn .chev {
+  font-size: 0.7rem;
+  color: var(--text-muted);
+}
+
+.env-columns-panel {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  z-index: 50;
+  width: 220px;
+  max-height: 280px;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+}
+
+.env-columns-panel[hidden] { display: none !important; }
+
+.env-picker-list {
+  overflow-y: auto;
+  padding: 0.35rem 0;
+  flex: 1;
+}
+
+.env-picker-list label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0;
+  padding: 0.45rem 0.75rem;
+  font-size: 0.85rem;
+  color: var(--text);
+  cursor: pointer;
+}
+
+.env-picker-list label:hover { background: var(--bg-card); }
+
+.env-picker-list input { width: auto; margin: 0; flex-shrink: 0; }
+
+.env-panel-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-top: 1px solid var(--border);
+}
+
+.env-panel-hint {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.env-picker-list label.is-disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+/* Pagination */
+.var-pagination {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+  padding: 0.65rem 1rem;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font-size: 0.85rem;
+}
+
+.var-pagination:empty { display: none; }
+
+.var-pagination-info { color: var(--text-muted); }
+
+.var-pagination-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.var-pagination-controls label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.var-pagination-controls select {
+  width: auto;
+  padding: 0.35rem 0.5rem;
+  font-size: 0.85rem;
+}
+
+.var-page-btns { display: flex; gap: 0.25rem; }
+
+.var-table-wrap {
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-card);
+}
+
+.var-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.88rem;
+  min-width: 480px;
+}
+
+.var-table th,
+.var-table td {
+  border-bottom: 1px solid var(--border);
+  padding: 0.5rem 0.65rem;
+  vertical-align: middle;
+}
+
+.var-table th {
+  background: var(--bg-elevated);
+  font-weight: 600;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  text-align: left;
+  white-space: nowrap;
+  position: sticky;
+  top: 0;
+  z-index: 2;
+}
+
+.var-table th.col-key,
+.var-table td.col-key {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+  background: var(--bg-card);
+  min-width: 160px;
+  max-width: 220px;
+}
+
+.var-table th.col-key { z-index: 3; background: var(--bg-elevated); }
+
+.var-table th.col-actions,
+.var-table td.col-actions {
+  width: 52px;
+  text-align: center;
+}
+
+.var-table tbody tr:hover td { background: rgba(88, 166, 255, 0.04); }
+.var-table tbody tr:hover td.col-key { background: var(--bg-card); }
+
+.var-table td input {
+  width: 100%;
+  min-width: 120px;
+  padding: 0.4rem 0.5rem;
+  font-family: var(--mono);
+  font-size: 0.82rem;
+}
+
+.var-table td.col-key input { font-weight: 500; }
+
+.var-table tfoot td {
+  background: var(--bg-elevated);
+  border-bottom: none;
+}
+
+.var-table tfoot .col-key input { font-weight: 600; }
+
+.var-table .row-dirty td { background: rgba(88, 166, 255, 0.06); }
+
+.var-table-empty {
+  padding: 2rem;
+  text-align: center;
+  color: var(--text-muted);
+}
+
+@media (max-width: 768px) {
+  .app {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto auto 1fr;
+  }
+
+  .nav-toggle { display: block; }
+
+  .nav {
+    display: none;
+    flex-direction: row;
+    flex-wrap: wrap;
+    border-right: none;
+    border-bottom: 1px solid var(--border);
+    padding: 0.5rem;
+  }
+
+  .nav.open { display: flex; }
+
+  .nav-item { flex: 1; min-width: 100px; text-align: center; }
+
+  .main { padding: 1rem; }
+
+  .form-inline { flex-direction: column; align-items: stretch; }
+  .form-inline input[type="number"] { width: 100%; }
+
+  .list-item { flex-direction: column; align-items: flex-start; }
+  .list-item .actions { width: 100%; }
+
+  .template-item { gap: 1rem; padding: 1rem; }
+  .template-meta { padding-right: 0; width: 100%; }
+  .template-actions {
+    flex-direction: row;
+    flex-wrap: wrap;
+    width: 100%;
+    min-width: 0;
+  }
+  .template-actions .btn { width: auto; }
+
+  .var-toolbar { flex-direction: column; align-items: stretch; }
+  .var-search { max-width: none; }
+}

--- a/internal/envmanager/web/app.js
+++ b/internal/envmanager/web/app.js
@@ -1,0 +1,862 @@
+(function () {
+  const ENV_COLUMNS_KEY = 'elsa-env-columns';
+  const PAGE_SIZE_KEY = 'elsa-env-page-size';
+  const PAGE_SIZES = [10, 25, 50, 100];
+  const MAX_ENV_COLUMNS = 5;
+
+  const state = {
+    environments: [],
+    variables: [],
+    templates: [],
+    selectedEnvIds: [],
+    varSearch: '',
+    varPage: 1,
+    varPageSize: 10,
+    envPanelOpen: false,
+    editingTplId: null,
+    exportMode: null, // 'template' | 'dotenv'
+    exportTemplateId: null,
+    savingRows: new Set(),
+  };
+
+  const $ = (sel) => document.querySelector(sel);
+  const $$ = (sel) => document.querySelectorAll(sel);
+
+  async function api(path, opts = {}) {
+    const res = await fetch(path, {
+      headers: { 'Content-Type': 'application/json' },
+      ...opts,
+    });
+    const text = await res.text();
+    let data = null;
+    if (text) {
+      try {
+        data = JSON.parse(text);
+      } catch {
+        data = { error: text };
+      }
+    }
+    if (!res.ok) {
+      throw new Error(data?.error || res.statusText);
+    }
+    return data;
+  }
+
+  function toast(msg, type = 'success') {
+    const el = $('#toast');
+    el.textContent = msg;
+    el.className = 'toast ' + type;
+    el.hidden = false;
+    setTimeout(() => { el.hidden = true; }, 2800);
+  }
+
+  function showPage(name) {
+    $$('.page').forEach((p) => p.classList.remove('active'));
+    $$('.nav-item').forEach((n) => n.classList.remove('active'));
+    $(`#page-${name}`)?.classList.add('active');
+    $(`.nav-item[data-page="${name}"]`)?.classList.add('active');
+    $('#mainNav')?.classList.remove('open');
+    if (name === 'variables') {
+      renderEnvPicker();
+      renderVariables();
+    }
+  }
+
+  // Navigation
+  $$('.nav-item').forEach((btn) => {
+    btn.addEventListener('click', () => showPage(btn.dataset.page));
+  });
+  $('#navToggle')?.addEventListener('click', () => {
+    $('#mainNav')?.classList.toggle('open');
+  });
+
+  $$('[data-close]').forEach((el) => {
+    el.addEventListener('click', () => {
+      el.closest('dialog')?.close();
+    });
+  });
+
+  // --- Environments ---
+  function loadSelectedEnvIds() {
+    try {
+      const raw = localStorage.getItem(ENV_COLUMNS_KEY);
+      if (raw) {
+        const ids = JSON.parse(raw);
+        if (Array.isArray(ids)) return ids.map(Number).filter(Boolean);
+      }
+    } catch { /* ignore */ }
+    return [];
+  }
+
+  function saveSelectedEnvIds() {
+    localStorage.setItem(ENV_COLUMNS_KEY, JSON.stringify(state.selectedEnvIds));
+    updateEnvColumnsSummary();
+  }
+
+  function loadPageSize() {
+    try {
+      const n = parseInt(localStorage.getItem(PAGE_SIZE_KEY), 10);
+      if (PAGE_SIZES.includes(n)) return n;
+    } catch { /* ignore */ }
+    return 10;
+  }
+
+  function savePageSize() {
+    localStorage.setItem(PAGE_SIZE_KEY, String(state.varPageSize));
+  }
+
+  function updateEnvColumnsSummary() {
+    const el = $('#envColumnsSummary');
+    if (!el) return;
+    const names = state.environments
+      .filter((e) => state.selectedEnvIds.includes(e.id))
+      .map((e) => e.name);
+    if (!names.length) {
+      el.textContent = 'None selected';
+      return;
+    }
+    if (names.length <= 2) {
+      el.textContent = names.join(', ');
+      return;
+    }
+    el.textContent = `${names.slice(0, 2).join(', ')} +${names.length - 2}`;
+  }
+
+  function setEnvPanelOpen(open) {
+    state.envPanelOpen = open;
+    const panel = $('#envColumnsPanel');
+    const btn = $('#envColumnsBtn');
+    if (panel) panel.hidden = !open;
+    if (btn) btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+  }
+
+  function clampSelectedEnvIds(ids) {
+    return ids.slice(0, MAX_ENV_COLUMNS);
+  }
+
+  function syncSelectedEnvIds() {
+    const valid = new Set(state.environments.map((e) => e.id));
+    let ids = state.selectedEnvIds.filter((id) => valid.has(id));
+    if (!ids.length && state.environments.length) {
+      ids = state.environments.slice(0, MAX_ENV_COLUMNS).map((e) => e.id);
+    }
+    const trimmed = clampSelectedEnvIds(ids);
+    if (trimmed.length < ids.length) {
+      toast(`Maximum ${MAX_ENV_COLUMNS} environment columns`, 'error');
+    }
+    state.selectedEnvIds = trimmed;
+    saveSelectedEnvIds();
+  }
+
+  function getVisibleEnvironments() {
+    return state.environments.filter((e) => state.selectedEnvIds.includes(e.id));
+  }
+
+  async function loadEnvironments() {
+    state.environments = await api('/api/environments');
+    if (!state.selectedEnvIds.length) {
+      state.selectedEnvIds = loadSelectedEnvIds();
+    }
+    syncSelectedEnvIds();
+    renderEnvironments();
+    renderEnvPicker();
+    fillExportEnvSelect();
+    if ($('#page-variables')?.classList.contains('active')) {
+      renderVariables();
+    }
+  }
+
+  function renderEnvironments() {
+    const list = $('#envList');
+    if (!state.environments.length) {
+      list.innerHTML = '<div class="empty">No environments yet. Add your first group above.</div>';
+      return;
+    }
+    list.innerHTML = state.environments
+      .map(
+        (e) => `
+      <div class="list-item" data-id="${e.id}">
+        <div class="meta">
+          <div class="title">${escapeHtml(e.name)}</div>
+          <div class="sub">Order: ${e.sort_order}</div>
+        </div>
+        <div class="actions">
+          <button type="button" class="btn small" data-export-env="${e.id}">Export .env</button>
+          <button type="button" class="btn small" data-edit-env="${e.id}">Edit</button>
+          <button type="button" class="btn small danger" data-del-env="${e.id}">Delete</button>
+        </div>
+      </div>`
+      )
+      .join('');
+
+    list.querySelectorAll('[data-export-env]').forEach((btn) => {
+      btn.addEventListener('click', () => openExport('dotenv', null, +btn.dataset.exportEnv));
+    });
+    list.querySelectorAll('[data-edit-env]').forEach((btn) => {
+      btn.addEventListener('click', () => editEnvironment(+btn.dataset.editEnv));
+    });
+    list.querySelectorAll('[data-del-env]').forEach((btn) => {
+      btn.addEventListener('click', () => deleteEnvironment(+btn.dataset.delEnv));
+    });
+  }
+
+  function resetEnvForm() {
+    const form = $('#envForm');
+    if (!form) return;
+    delete form.dataset.editId;
+    $('#envName').value = '';
+    $('#envSort').value = '0';
+    const btn = form.querySelector('button[type="submit"]');
+    if (btn) btn.textContent = 'Add';
+  }
+
+  $('#envForm')?.addEventListener('submit', async (ev) => {
+    ev.preventDefault();
+    const name = $('#envName').value.trim();
+    const sort_order = parseInt($('#envSort').value, 10) || 0;
+    const editId = $('#envForm').dataset.editId;
+
+    try {
+      if (editId) {
+        await api(`/api/environments/${editId}`, {
+          method: 'PUT',
+          body: JSON.stringify({ name, sort_order }),
+        });
+      } else {
+        await api('/api/environments', {
+          method: 'POST',
+          body: JSON.stringify({ name, sort_order }),
+        });
+      }
+      resetEnvForm();
+      await loadEnvironments();
+      await loadVariables();
+      toast('Environment saved');
+    } catch (err) {
+      toast(err.message, 'error');
+      if (editId && /not found/i.test(err.message)) {
+        resetEnvForm();
+      }
+    }
+  });
+
+  function editEnvironment(id) {
+    const e = state.environments.find((x) => x.id === id);
+    if (!e) return;
+    $('#envName').value = e.name;
+    $('#envSort').value = e.sort_order;
+    $('#envForm').dataset.editId = String(id);
+    $('#envForm button[type="submit"]').textContent = 'Update';
+    $('#envName').focus();
+  }
+
+  async function deleteEnvironment(id) {
+    if (!confirm('Delete this environment and all its values?')) return;
+    try {
+      await api(`/api/environments/${id}`, { method: 'DELETE' });
+      await loadEnvironments();
+      const editingId = $('#envForm')?.dataset.editId;
+      if (editingId && !state.environments.some((e) => e.id === +editingId)) {
+        resetEnvForm();
+      }
+      await loadVariables();
+      toast('Deleted');
+    } catch (err) {
+      toast(err.message, 'error');
+    }
+  }
+
+  // --- Variables (table view) ---
+  function applyEnvColumnSelection(fromPicker) {
+    if (fromPicker) {
+      const box = $('#varEnvPicker');
+      const checked = [...box.querySelectorAll('input:checked')];
+      if (checked.length > MAX_ENV_COLUMNS) {
+        const last = checked[checked.length - 1];
+        last.checked = false;
+        state.selectedEnvIds = checked.slice(0, MAX_ENV_COLUMNS).map((x) => +x.value);
+        toast(`Maximum ${MAX_ENV_COLUMNS} environment columns`, 'error');
+      } else {
+        state.selectedEnvIds = checked.map((x) => +x.value);
+      }
+    }
+    if (!state.selectedEnvIds.length && state.environments.length) {
+      state.selectedEnvIds = [state.environments[0].id];
+      if (fromPicker) renderEnvPicker();
+      toast('At least one environment column is required', 'error');
+    }
+    state.selectedEnvIds = clampSelectedEnvIds(state.selectedEnvIds);
+    saveSelectedEnvIds();
+    state.varPage = 1;
+    renderEnvPicker();
+    renderVariables();
+  }
+
+  function renderEnvPicker() {
+    const box = $('#varEnvPicker');
+    if (!box) return;
+    if (!state.environments.length) {
+      box.innerHTML = '<div class="sub" style="padding:0.5rem 0.75rem">Add environments first.</div>';
+      updateEnvColumnsSummary();
+      return;
+    }
+    box.innerHTML = state.environments
+      .map(
+        (e) => `
+      <label>
+        <input type="checkbox" value="${e.id}" ${state.selectedEnvIds.includes(e.id) ? 'checked' : ''}>
+        <span>${escapeHtml(e.name)}</span>
+      </label>`
+      )
+      .join('');
+
+    const atMax = state.selectedEnvIds.length >= MAX_ENV_COLUMNS;
+    box.querySelectorAll('input').forEach((cb) => {
+      const disabled = atMax && !cb.checked;
+      cb.disabled = disabled;
+      cb.closest('label')?.classList.toggle('is-disabled', disabled);
+      cb.addEventListener('change', () => applyEnvColumnSelection(true));
+    });
+    updateEnvColumnsSummary();
+  }
+
+  function renderPagination(totalItems) {
+    const el = $('#varPagination');
+    if (!el) return;
+
+    if (!totalItems) {
+      el.innerHTML = '';
+      return;
+    }
+
+    const totalPages = Math.max(1, Math.ceil(totalItems / state.varPageSize));
+    if (state.varPage > totalPages) state.varPage = totalPages;
+    if (state.varPage < 1) state.varPage = 1;
+
+    const start = (state.varPage - 1) * state.varPageSize + 1;
+    const end = Math.min(state.varPage * state.varPageSize, totalItems);
+
+    const sizeOptions = PAGE_SIZES.map(
+      (n) => `<option value="${n}" ${n === state.varPageSize ? 'selected' : ''}>${n}</option>`
+    ).join('');
+
+    el.innerHTML = `
+      <div class="var-pagination-info">
+        Showing ${start}–${end} of ${totalItems} keys
+      </div>
+      <div class="var-pagination-controls">
+        <label>
+          Per page
+          <select id="varPageSize">${sizeOptions}</select>
+        </label>
+        <div class="var-page-btns">
+          <button type="button" class="btn small" id="varPagePrev" ${state.varPage <= 1 ? 'disabled' : ''}>Prev</button>
+          <span>${state.varPage} / ${totalPages}</span>
+          <button type="button" class="btn small" id="varPageNext" ${state.varPage >= totalPages ? 'disabled' : ''}>Next</button>
+        </div>
+      </div>`;
+
+    $('#varPageSize')?.addEventListener('change', (ev) => {
+      state.varPageSize = parseInt(ev.target.value, 10);
+      savePageSize();
+      state.varPage = 1;
+      renderVariables();
+    });
+    $('#varPagePrev')?.addEventListener('click', () => {
+      if (state.varPage > 1) {
+        state.varPage--;
+        renderVariables();
+      }
+    });
+    $('#varPageNext')?.addEventListener('click', () => {
+      const tp = Math.ceil(totalItems / state.varPageSize);
+      if (state.varPage < tp) {
+        state.varPage++;
+        renderVariables();
+      }
+    });
+  }
+
+  async function loadVariables() {
+    state.variables = await api('/api/variables');
+    renderVariables();
+  }
+
+  function getValueForEnv(variable, envId) {
+    const found = (variable.values || []).find((v) => v.environment_id === envId);
+    return found ? found.value : '';
+  }
+
+  function sortVariablesByKey(list) {
+    return [...list].sort((a, b) => a.key.localeCompare(b.key, undefined, { sensitivity: 'base' }));
+  }
+
+  function filterVariablesBySearch(list) {
+    const q = state.varSearch.trim().toLowerCase();
+    if (!q) return list;
+    return list.filter((v) => v.key.toLowerCase().includes(q));
+  }
+
+  function renderVariables() {
+    const wrap = $('#varTableWrap');
+    if (!wrap) return;
+
+    const cols = getVisibleEnvironments();
+
+    if (!state.environments.length) {
+      wrap.innerHTML = '<div class="var-table-empty">Create environment groups first (Environments page).</div>';
+      if ($('#varPagination')) $('#varPagination').innerHTML = '';
+      return;
+    }
+
+    if (!cols.length) {
+      wrap.innerHTML = '<div class="var-table-empty">Select at least one environment column above.</div>';
+      if ($('#varPagination')) $('#varPagination').innerHTML = '';
+      return;
+    }
+
+    const filtered = filterVariablesBySearch(sortVariablesByKey(state.variables));
+    const totalItems = filtered.length;
+    const totalPages = Math.max(1, Math.ceil(totalItems / state.varPageSize));
+    if (state.varPage > totalPages) state.varPage = totalPages;
+    const pageOffset = (state.varPage - 1) * state.varPageSize;
+    const pageItems = filtered.slice(pageOffset, pageOffset + state.varPageSize);
+
+    renderPagination(totalItems);
+
+    const colHeaders = cols
+      .map((e) => `<th>${escapeHtml(e.name)}</th>`)
+      .join('');
+
+    const noSearchHits = state.variables.length > 0 && !filtered.length;
+    const bodyRows = pageItems.length
+      ? pageItems
+          .map((v) => {
+            const cells = cols
+              .map(
+                (e) => `
+            <td>
+              <input type="text" data-env-id="${e.id}" value="${escapeAttr(getValueForEnv(v, e.id))}" placeholder="—">
+            </td>`
+              )
+              .join('');
+            return `
+          <tr data-var-id="${v.id}">
+            <td class="col-key">
+              <input type="text" class="input-key" value="${escapeAttr(v.key)}" title="${escapeAttr(v.description || '')}">
+            </td>
+            ${cells}
+            <td class="col-actions">
+              <button type="button" class="btn icon danger" data-del-var="${v.id}" title="Delete">✕</button>
+            </td>
+          </tr>`;
+          })
+          .join('')
+      : noSearchHits
+        ? `<tr><td colspan="${cols.length + 2}" class="var-table-empty">No keys match your search.</td></tr>`
+        : '';
+
+    const addCells = cols
+      .map(
+        (e) => `
+        <td>
+          <input type="text" data-add-env="${e.id}" placeholder="Value">
+        </td>`
+      )
+      .join('');
+
+    wrap.innerHTML = `
+      <table class="var-table">
+        <thead>
+          <tr>
+            <th class="col-key">Key</th>
+            ${colHeaders}
+            <th class="col-actions"></th>
+          </tr>
+        </thead>
+        <tbody>${bodyRows}</tbody>
+        <tfoot>
+          <tr id="varAddRow">
+            <td class="col-key">
+              <input type="text" id="addVarKey" placeholder="NEW_KEY" required>
+            </td>
+            ${addCells}
+            <td class="col-actions">
+              <button type="button" class="btn small primary" id="btnAddVariable">Add</button>
+            </td>
+          </tr>
+        </tfoot>
+      </table>`;
+
+    wrap.querySelectorAll('tbody tr[data-var-id]').forEach((row) => {
+      const varId = +row.dataset.varId;
+      row.querySelectorAll('input').forEach((inp) => {
+        inp.addEventListener('input', () => row.classList.add('row-dirty'));
+        inp.addEventListener('keydown', (ev) => {
+          if (ev.key === 'Enter') {
+            ev.preventDefault();
+            inp.blur();
+          }
+        });
+        inp.addEventListener('blur', () => {
+          if (row.classList.contains('row-dirty')) saveVariableRow(varId, row);
+        });
+      });
+    });
+
+    wrap.querySelectorAll('[data-del-var]').forEach((btn) => {
+      btn.addEventListener('click', () => deleteVariable(+btn.dataset.delVar));
+    });
+
+    $('#btnAddVariable')?.addEventListener('click', addVariableFromFooter);
+    $('#addVarKey')?.addEventListener('keydown', (ev) => {
+      if (ev.key === 'Enter') {
+        ev.preventDefault();
+        addVariableFromFooter();
+      }
+    });
+  }
+
+  function readRowPayload(row) {
+    const key = row.querySelector('.input-key, #addVarKey')?.value.trim() || '';
+    const cols = getVisibleEnvironments();
+    const environment_ids = cols.map((e) => e.id);
+    const values = cols.map((e) => {
+      const inp = row.querySelector(`input[data-env-id="${e.id}"], input[data-add-env="${e.id}"]`);
+      return { environment_id: e.id, value: inp?.value ?? '' };
+    });
+    return { key, description: '', environment_ids, values };
+  }
+
+  async function saveVariableRow(varId, row) {
+    if (state.savingRows.has(varId)) return;
+    const payload = readRowPayload(row);
+    if (!payload.key) {
+      toast('Key cannot be empty', 'error');
+      return;
+    }
+
+    const original = state.variables.find((v) => v.id === varId);
+    if (original && original.key === payload.key) {
+      const unchanged = getVisibleEnvironments().every((e) => {
+        const inp = row.querySelector(`input[data-env-id="${e.id}"]`);
+        return (inp?.value ?? '') === getValueForEnv(original, e.id);
+      });
+      if (unchanged) {
+        row.classList.remove('row-dirty');
+        return;
+      }
+    }
+
+    state.savingRows.add(varId);
+    try {
+      await api(`/api/variables/${varId}`, {
+        method: 'PUT',
+        body: JSON.stringify(payload),
+      });
+      await loadVariables();
+      toast('Saved');
+    } catch (err) {
+      toast(err.message, 'error');
+    } finally {
+      state.savingRows.delete(varId);
+    }
+  }
+
+  async function addVariableFromFooter() {
+    const row = $('#varAddRow');
+    if (!row) return;
+    const payload = readRowPayload(row);
+    if (!payload.key) {
+      toast('Enter a key name', 'error');
+      $('#addVarKey')?.focus();
+      return;
+    }
+    try {
+      await api('/api/variables', {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      });
+      row.querySelectorAll('input').forEach((inp) => { inp.value = ''; });
+      await loadVariables();
+      toast('Variable added');
+    } catch (err) {
+      toast(err.message, 'error');
+    }
+  }
+
+  async function deleteVariable(id) {
+    if (!confirm('Delete this variable?')) return;
+    try {
+      await api(`/api/variables/${id}`, { method: 'DELETE' });
+      await loadVariables();
+      toast('Deleted');
+    } catch (err) {
+      toast(err.message, 'error');
+    }
+  }
+
+  $('#varSearch')?.addEventListener('input', (ev) => {
+    state.varSearch = ev.target.value;
+    state.varPage = 1;
+    renderVariables();
+  });
+
+  $('#envColumnsBtn')?.addEventListener('click', (ev) => {
+    ev.stopPropagation();
+    setEnvPanelOpen(!state.envPanelOpen);
+  });
+
+  $('#envSelectAll')?.addEventListener('click', () => {
+    state.selectedEnvIds = state.environments.slice(0, MAX_ENV_COLUMNS).map((e) => e.id);
+    if (state.environments.length > MAX_ENV_COLUMNS) {
+      toast(`Maximum ${MAX_ENV_COLUMNS} columns (first ${MAX_ENV_COLUMNS} selected)`, 'error');
+    }
+    applyEnvColumnSelection(false);
+  });
+
+  document.addEventListener('click', (ev) => {
+    if (!state.envPanelOpen) return;
+    const wrap = $('.env-columns-wrap');
+    if (wrap && !wrap.contains(ev.target)) setEnvPanelOpen(false);
+  });
+
+  // --- Templates ---
+  async function loadTemplates() {
+    state.templates = await api('/api/templates');
+    renderTemplates();
+  }
+
+  function renderTemplates() {
+    const list = $('#templateList');
+    if (!state.templates.length) {
+      list.innerHTML = '<div class="empty">No templates yet.</div>';
+      return;
+    }
+    list.innerHTML = state.templates
+      .map(
+        (t) => `
+      <div class="list-item template-item">
+        <div class="template-meta">
+          <div class="template-title">${escapeHtml(t.name)}</div>
+          <pre class="template-preview">${escapeHtml(t.body)}</pre>
+        </div>
+        <div class="template-actions">
+          <button type="button" class="btn small" data-export-tpl="${t.id}">Export</button>
+          <button type="button" class="btn small" data-edit-tpl="${t.id}">Edit</button>
+          <button type="button" class="btn small danger" data-del-tpl="${t.id}">Delete</button>
+        </div>
+      </div>`
+      )
+      .join('');
+
+    list.querySelectorAll('[data-export-tpl]').forEach((btn) => {
+      btn.addEventListener('click', () => openExport('template', +btn.dataset.exportTpl));
+    });
+    list.querySelectorAll('[data-edit-tpl]').forEach((btn) => {
+      btn.addEventListener('click', () => openTplModal(+btn.dataset.editTpl));
+    });
+    list.querySelectorAll('[data-del-tpl]').forEach((btn) => {
+      btn.addEventListener('click', () => deleteTemplate(+btn.dataset.delTpl));
+    });
+  }
+
+  function openTplModal(id = null) {
+    state.editingTplId = id;
+    $('#tplModalTitle').textContent = id ? 'Edit template' : 'New template';
+    $('#tplName').value = '';
+    $('#tplBody').value = '';
+    if (id) {
+      const t = state.templates.find((x) => x.id === id);
+      if (t) {
+        $('#tplName').value = t.name;
+        $('#tplBody').value = t.body;
+      }
+    } else {
+      $('#tplBody').value = `DB_HOST={{.DB_HOST}}
+DB_USER={{.DB_USER}}
+DB_PASS={{.DB_PASS}}
+DB_PORT={{.DB_PORT}}`;
+    }
+    $('#tplModal').showModal();
+  }
+
+  $('#btnNewTemplate')?.addEventListener('click', () => openTplModal());
+
+  function validateTemplateForm(name, body) {
+    if (!name) {
+      toast('Template name is required', 'error');
+      return false;
+    }
+    if (!body.trim()) {
+      toast('Template body is required', 'error');
+      return false;
+    }
+    const dup = state.templates.find(
+      (t) =>
+        t.name.toLowerCase() === name.toLowerCase() &&
+        t.id !== state.editingTplId
+    );
+    if (dup) {
+      toast(`Template name "${name}" already exists`, 'error');
+      return false;
+    }
+    return true;
+  }
+
+  $('#tplForm')?.addEventListener('submit', async (ev) => {
+    ev.preventDefault();
+    const name = $('#tplName').value.trim();
+    const body = $('#tplBody').value;
+    if (!validateTemplateForm(name, body)) return;
+    try {
+      if (state.editingTplId) {
+        await api(`/api/templates/${state.editingTplId}`, {
+          method: 'PUT',
+          body: JSON.stringify({ name, body }),
+        });
+      } else {
+        await api('/api/templates', { method: 'POST', body: JSON.stringify({ name, body }) });
+      }
+      $('#tplModal').close();
+      await loadTemplates();
+      toast('Template saved');
+    } catch (err) {
+      toast(err.message, 'error');
+    }
+  });
+
+  async function deleteTemplate(id) {
+    if (!confirm('Delete this template?')) return;
+    try {
+      await api(`/api/templates/${id}`, { method: 'DELETE' });
+      await loadTemplates();
+      toast('Deleted');
+    } catch (err) {
+      toast(err.message, 'error');
+    }
+  }
+
+  // --- Export ---
+  function fillExportEnvSelect() {
+    const sel = $('#exportEnv');
+    if (!sel) return;
+    sel.innerHTML = state.environments
+      .map((e) => `<option value="${e.id}">${escapeHtml(e.name)}</option>`)
+      .join('');
+  }
+
+  function openExport(mode, templateId, envId) {
+    state.exportMode = mode;
+    state.exportTemplateId = templateId;
+    fillExportEnvSelect();
+    if (envId) $('#exportEnv').value = envId;
+    $('#exportFilename').value = '';
+    $('#exportPreview').textContent = '';
+    $('#exportModal').showModal();
+    runExport();
+  }
+
+  async function runExport() {
+    const envId = +$('#exportEnv').value;
+    const filename = $('#exportFilename').value.trim();
+    if (!envId) {
+      toast('Select an environment', 'error');
+      return;
+    }
+    try {
+      let result;
+      if (state.exportMode === 'template' && state.exportTemplateId) {
+        result = await api(`/api/templates/${state.exportTemplateId}/render`, {
+          method: 'POST',
+          body: JSON.stringify({ environment_id: envId, filename }),
+        });
+      } else {
+        result = await api(`/api/environments/${envId}/export`, {
+          method: 'POST',
+          body: JSON.stringify({ filename }),
+        });
+      }
+      $('#exportPreview').textContent = result.content;
+      if (result.filename && !$('#exportFilename').value.trim()) {
+        $('#exportFilename').placeholder = result.filename;
+      }
+      state.lastExport = result;
+    } catch (err) {
+      toast(err.message, 'error');
+    }
+  }
+
+  $('#btnRefreshExport')?.addEventListener('click', runExport);
+  $('#exportEnv')?.addEventListener('change', runExport);
+
+  $$('[data-close-export]').forEach((el) => {
+    el.addEventListener('click', () => $('#exportModal').close());
+  });
+
+  $('#btnCopyExport')?.addEventListener('click', async () => {
+    const text = $('#exportPreview').textContent;
+    if (!text) {
+      toast('Generate preview first', 'error');
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(text);
+      toast('Copied to clipboard');
+    } catch {
+      toast('Copy failed — select text manually', 'error');
+    }
+  });
+
+  $('#btnDownloadExport')?.addEventListener('click', () => {
+    const text = $('#exportPreview').textContent;
+    if (!text) {
+      toast('Generate preview first', 'error');
+      return;
+    }
+    const name =
+      $('#exportFilename').value.trim() ||
+      state.lastExport?.filename ||
+      '.env';
+    const blob = new Blob([text], { type: 'text/plain' });
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = name;
+    a.click();
+    URL.revokeObjectURL(a.href);
+    toast('Downloaded');
+  });
+
+  function escapeHtml(s) {
+    return String(s)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  function escapeAttr(s) {
+    return escapeHtml(s).replace(/'/g, '&#39;');
+  }
+
+  function truncate(s, n) {
+    s = String(s).replace(/\n/g, ' ');
+    return s.length > n ? s.slice(0, n) + '…' : s;
+  }
+
+  // Init
+  async function init() {
+    state.selectedEnvIds = loadSelectedEnvIds();
+    state.varPageSize = loadPageSize();
+    try {
+      await loadEnvironments();
+      await loadVariables();
+      await loadTemplates();
+      renderEnvPicker();
+    } catch (err) {
+      toast('Failed to load: ' + err.message, 'error');
+    }
+  }
+
+  init();
+})();

--- a/internal/envmanager/web/index.html
+++ b/internal/envmanager/web/index.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Elsa Env Manager</title>
+  <link rel="stylesheet" href="/static/app.css">
+</head>
+<body>
+  <div class="app">
+    <header class="header">
+      <div class="brand">
+        <span class="logo">◆</span>
+        <div>
+          <h1>Elsa Env</h1>
+          <p class="tagline">Local environment manager</p>
+        </div>
+      </div>
+      <button type="button" class="nav-toggle" id="navToggle" aria-label="Menu">☰</button>
+    </header>
+
+    <nav class="nav" id="mainNav">
+      <button type="button" class="nav-item active" data-page="environments">Environments</button>
+      <button type="button" class="nav-item" data-page="variables">Variables</button>
+      <button type="button" class="nav-item" data-page="templates">Templates</button>
+    </nav>
+
+    <main class="main">
+      <!-- Environments -->
+      <section id="page-environments" class="page active">
+        <div class="page-header">
+          <h2>Environment groups</h2>
+          <p>Create custom groups like local, staging, or production.</p>
+        </div>
+        <form id="envForm" class="card form-inline">
+          <input type="text" id="envName" placeholder="Name (e.g. staging)" required>
+          <input type="number" id="envSort" placeholder="Order" value="0" min="0">
+          <button type="submit" class="btn primary">Add</button>
+        </form>
+        <div id="envList" class="list"></div>
+      </section>
+
+      <!-- Variables -->
+      <section id="page-variables" class="page">
+        <div class="page-header">
+          <h2>Variables</h2>
+          <p>Compare values across environments. Edit per row; add new keys in the table footer.</p>
+        </div>
+        <div class="var-toolbar card">
+          <input type="search" id="varSearch" class="var-search" placeholder="Search by key name…" autocomplete="off">
+          <div class="env-columns-wrap">
+            <button type="button" id="envColumnsBtn" class="btn env-columns-btn" aria-haspopup="listbox" aria-expanded="false">
+              <span class="env-columns-label">Columns</span>
+              <span id="envColumnsSummary" class="env-columns-summary">—</span>
+              <span class="chev" aria-hidden="true">▾</span>
+            </button>
+            <div id="envColumnsPanel" class="env-columns-panel" hidden>
+              <div id="varEnvPicker" class="env-picker-list"></div>
+              <div class="env-panel-footer">
+                <span class="env-panel-hint">Max 5 columns</span>
+                <button type="button" class="btn small" id="envSelectAll">Select max</button>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div id="varTableWrap" class="var-table-wrap"></div>
+        <div id="varPagination" class="var-pagination"></div>
+      </section>
+
+      <!-- Templates -->
+      <section id="page-templates" class="page">
+        <div class="page-header">
+          <h2>Templates</h2>
+          <p>Use Go template syntax: <code>{{.DB_HOST}}</code> — keys match your variable names.</p>
+        </div>
+        <button type="button" class="btn primary tpl-new-btn" id="btnNewTemplate">+ New template</button>
+        <div id="templateList" class="list template-list"></div>
+      </section>
+    </main>
+  </div>
+
+  <!-- Template modal -->
+  <dialog id="tplModal" class="modal">
+    <form method="dialog" id="tplForm">
+      <div class="modal-header">
+        <h3 id="tplModalTitle">Template</h3>
+        <button type="button" class="btn icon" data-close>✕</button>
+      </div>
+      <div class="modal-body">
+        <label>Name
+          <input type="text" id="tplName" required placeholder="e.g. dotenv-default" autocomplete="off">
+          <span class="field-hint">Must be unique (case-insensitive)</span>
+        </label>
+        <label>Body
+          <textarea id="tplBody" rows="12" required placeholder="DB_HOST={{.DB_HOST}}&#10;DB_USER={{.DB_USER}}"></textarea>
+        </label>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn" data-close>Cancel</button>
+        <button type="submit" class="btn primary">Save</button>
+      </div>
+    </form>
+  </dialog>
+
+  <!-- Export modal -->
+  <dialog id="exportModal" class="modal">
+    <div class="modal-header">
+      <h3>Export</h3>
+      <button type="button" class="btn icon" data-close-export>✕</button>
+    </div>
+    <div class="modal-body">
+      <label>Environment
+        <select id="exportEnv"></select>
+      </label>
+      <label>Filename
+        <input type="text" id="exportFilename" placeholder=".env">
+      </label>
+      <label class="preview-label">Preview</label>
+      <pre id="exportPreview" class="preview"></pre>
+    </div>
+    <div class="modal-footer">
+      <button type="button" class="btn" id="btnCopyExport">Copy</button>
+      <button type="button" class="btn" id="btnDownloadExport">Download</button>
+      <button type="button" class="btn primary" id="btnRefreshExport">Generate</button>
+    </div>
+  </dialog>
+
+  <div id="toast" class="toast" hidden></div>
+  <script src="/static/app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
- - **Elsa Env Manager** — local environment variable manager with embedded web UI
  - `elsa env serve` — start localhost web server (default `127.0.0.1:1999`)
  - `elsa env reset` — delete local database with 8-character random confirmation code
  - **Environments** — custom groups (local, staging, production, etc.) with sort order
  - **Variables** — comparison table across environments, per-row edit, search, pagination (10/25/50/100)
  - **Templates** — Go `text/template` export (`.env` or custom filename, copy/download)
  - Environment column picker (dropdown, max 5 columns at a time)
  - Auto-open system browser when `serve` starts (`--no-browser` to disable)
  - SQLite storage at user config dir: `elsa/elsaenvmanager.db` (local only, not published)
  - REST API for environments, variables, and templates
  - `ENV_GUIDELINE.md` — complete feature documentation